### PR TITLE
[FEAT] #46 로그인 버튼 > 로그인 시 메인화면으로 전환

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,16 +42,18 @@
             android:name=".SignUp"
             android:exported="true"
             android:parentActivityName=".SignIn">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+
             />
         </activity>
         <activity
             android:name=".SignIn"
-            android:exported="false"
-            android:parentActivityName=".MainActivity"/>
+            android:exported="true"
+            android:parentActivityName=".MainActivity">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+        </activity>
         <activity
             android:name=".pwFinding"
             android:exported="false"

--- a/app/src/main/java/com/example/playoke/SignIn.kt
+++ b/app/src/main/java/com/example/playoke/SignIn.kt
@@ -1,6 +1,8 @@
 package com.example.playoke
 
+import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -12,11 +14,49 @@ class SignIn : AppCompatActivity() {
     lateinit var binding: ActivitySignInBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         binding = ActivitySignInBinding.inflate(layoutInflater)
-
         super.onCreate(savedInstanceState)
-
         setContentView(binding.root)
         setSupportActionBar(binding.toolbar)
+
+        binding.toSignUp.setOnClickListener{ // 회원가입으로 이동
+            val intent: Intent = Intent(this, SignUp::class.java)
+            startActivity(intent)
+        }
+
+        binding.toIdPwFinding.setOnClickListener{ // 비밀번호 찾기로 이동
+            val intent: Intent = Intent(this, pwFinding::class.java)
+            startActivity(intent)
+        }
+
+        binding.signInBtn.setOnClickListener {
+            //이메일, 비밀번호 로그인.......................
+            val email: String = binding.email.text.toString()
+            val password: String = binding.pw.text.toString()
+            MyApplication.auth.signInWithEmailAndPassword(email, password)
+                .addOnCompleteListener(this) { task ->
+                    binding.email.text.clear()
+                    binding.pw.text.clear()
+                    if (task.isSuccessful) {
+                        if (MyApplication.checkAuth()) {
+                            // 로그인 성공
+                            MyApplication.email = email
+                            val intent: Intent = Intent(this, MainActivity::class.java)
+                            startActivity(intent)
+                        } else {
+// 발송된 메일로 인증 확인을 안 한 경우
+                            Toast.makeText(baseContext,
+                                "전송된 메일로 이메일 인증이 되지 않았습니다.",
+                                Toast.LENGTH_SHORT).show()
+                        }
+                    } else {
+                        Toast.makeText(baseContext, "로그인 실패",
+                            Toast.LENGTH_SHORT).show()
+                    }
+                }
+
+        }
+
+
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->


### PR DESCRIPTION
* 로그인 화면

- 이메일 미인증 사용자 로그인 시도 시 > 이메일 인증 요구 토스트 메시지
- 이메일/ 비밀번호 틀릴 시 > 확인 요구 토스트 메시지
- 올바른 이메일/비밀번호 입력 & 로그인 버튼 클릭 > 메인 액티비티로
- 비밀번호 찾기 클릭 > 비밀번호 찾기(미구현 상태)로 이동 
- 회원가입 클릭 > 회원가입으로 이동
- 회원가입 화면에서 업버튼 클릭 시 로그인 화면으로 이동하는 것 확인 완료